### PR TITLE
Fixes overticking issues

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -44,7 +44,9 @@ function download(src) {
         width: 40
       });
     }
-    bar.tick(state.received);
+    if(!bar.complete) {
+      bar.tick(state.received);
+    }
   }
 
   console.log("GET `" + src.url + "`");


### PR DESCRIPTION
`request-progress` seem to have more package received than total (sometimes). This change makes so over ticking becomes impossible.

Current over ticking issue:
![screen shot 2015-02-19 at 4 59 47 pm](https://cloud.githubusercontent.com/assets/1324476/6264682/edf67ee8-b860-11e4-95ce-c1994406eff5.png)