### PR TITLE
Fix calling callback twice when error is thrown

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,9 @@ module.exports = function(srcUrl, destPath, options, callback) {
     }
 
   // Done
-  }).catch(callback).done(function() {
-    callback();
+  }).catch(function (errorCatched) {
+		error = errorCatched;
+	}).done(function() {
+    callback(error);
   });
 };


### PR DESCRIPTION
when chained process throws error  [index.js](https://github.com/rxaviers/cldr-data-downloader/blob/master/index.js#L100) catches it and calls callback. Then done() calls callback again.

In my case express server initializes cldr-data before start listening requests. As far as callback is being called twice express server was throwing EADDRINUSE

I propose using catch for setting error and let done() method to call callback

`
}).catch(function (errorCatched) {
    error = errorCatched;
}).done(function () {
    callback(error);
});
` 
