### PR TITLE
Update request pkg, fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "npmconf": "2.0.9",
     "progress": "1.1.8",
     "q": "1.0.1",
-    "request": "2.72.0",
+    "request": "~2.74.0",
     "request-progress": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

`request@2.72.x` requires `tough-cookie@<2.3.0`, which has a security vulnerability: https://nodesecurity.io/advisories/130

## Solution

Update the `request` dependency