### PR TITLE
Add 'option.filterRe' & '--filter' (CLI) to restrict download URLs via regexp string

### DIFF
--- a/bin/download.js
+++ b/bin/download.js
@@ -29,6 +29,8 @@ function help() {
     "                          # key.",
     "  -o, --output            # Destination path to unpack JSONs at.",
     "  -f, --force             # Force to re-download and to re-unpack.",
+    "  --filter                # Regexp URL mask: '(core|numbers)' etc. Useful",
+    "                          # when input is for external .json config",
     ""
   ];
 
@@ -42,6 +44,7 @@ opts = nopt({
   input: String,
   "src-url-key": String,
   "coverage": String,
+  filter: String,
   output: path,
   force: Boolean
 }, {
@@ -66,6 +69,7 @@ if (opts.help || !requiredOpts) {
 }
 
 options.force = opts.force;
+options.filterRe = opts.filter;
 options.srcUrlKey = opts["src-url-key"] || opts.coverage;
 
 download(opts.input, opts.output, options, function(error) {

--- a/index.js
+++ b/index.js
@@ -68,6 +68,18 @@ module.exports = function(srcUrl, destPath, options, callback) {
   // Download
   }).then(function() {
     var srcUrls = alwaysArray(srcUrl);
+
+    if (options.filterRe) {
+      var filterRe = options.filterRe;
+      if (typeof filterRe === 'string') {
+        filterRe = new RegExp(filterRe);
+      }
+
+      srcUrls = srcUrls.filter(function(url) {
+        return filterRe.test(url);
+      });
+    }
+
     return Q.all(srcUrls.map(function(srcUrl) {
       return download({
         url: srcUrl


### PR DESCRIPTION
Needed for https://github.com/rxaviers/cldr-data-npm/issues/44

Quick test:

```sh
./bin/download.sh -i urls.json -o ./tmp -f --filter '(core|numbers)'
```