### PR TITLE
NodeJS 8 compatibility

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,7 +17,7 @@ module.exports = {
     try {
       assert.deepEqual(a, b);
     } catch (error) {
-      if (error.name === "AssertionError") {
+      if (error instanceof assert.AssertionError) {
         return false;
       }
       throw error;


### PR DESCRIPTION
NodeJS 8 introduced error codes and reading ```error.name``` returns ```AssertionError [ERR_ASSERTION]``` instead of just  ```AssertionError ```. Checking the error with instanceof adds compatibility for NodeJS 8 and is backwards compatible as well

https://nodejs.org/en/blog/release/v8.0.0/#static-error-codes