### PR TITLE
Add local file support to the download path

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -90,13 +90,14 @@ function fetchFromFilesystem(src) {
 
 function download(src) {
   // Modify the src to not be a file protocol uri so we can unify handling files
-  if (src.url && src.url.trim().toLowerCase().indexOf("file://") === 0) {
-    // Chop off the first 7 characters
-    src.url = src.url.trim().substr("file://".length);
-  }
+  src.url = src.url.trim();
+
+  // Modify the url to not be a file protocol uri so we can unify handling files.
+  src.url = src.url.replace(/^file:\/\//i, "");
+
   // Short circuit the download function and grab it from the filesystem if
   // we don't have anything that looks like a protocol (e.g. https/http/ftp/etc).
-  if (src.url && src.url.indexOf("://") === -1) {
+  if (src.url.indexOf("://") === -1) {
     return fetchFromFilesystem(src);
   }
 

--- a/lib/download.js
+++ b/lib/download.js
@@ -12,6 +12,9 @@ var extend = require("util")._extend;
 var Q = require("q");
 var requestProgress = require("request-progress");
 var request = require("request");
+var path = require("path");
+var fs = require("fs");
+var workingDir = process.cwd();
 
 function getRequestOptions(options) {
   options = extend(extend({}, options), {
@@ -31,7 +34,72 @@ function getRequestOptions(options) {
   return options;
 }
 
+function fetchFromFilesystem(src) {
+  var fsDfd = Q.defer();
+
+  // We don't need any options here, so we just grab the url
+  // and make sure it fits the norms for our platform.
+  var givenFilePath = path.normalize(src.url);
+
+  function notify(state) {
+    fsDfd.notify(state);
+  }
+
+  var filePath;
+
+  // Test if the file path is absolute. If not, then prepend the application
+  // directory beforehand, so it can be treated as relative from the app root.
+  if (path.isAbsolute(givenFilePath)) {
+    filePath = givenFilePath;
+  } else {
+    filePath = path.join(workingDir, givenFilePath);
+  }
+
+  console.log("Retrieving `" + filePath + "`");
+
+  // Getting the errors and size right on the progress bar here is not worth all the setup.
+  // Just fail silently here if there's a problem and the error will correctly bubble in the
+  // readFile call below.
+  var totalSize = 0;
+  try {
+    var stats = fs.statSync(filePath);
+    totalSize = stats.size;
+  } catch (e) {}
+
+
+  // We're gonna go from 0->100 with nothing between for fs.readFile. We could alternatively
+  // do a readStream, but it seems like overkill for the filesizes.
+  notify({total: totalSize, received: 0, percent: 0});
+
+  // Async request the file
+  fs.readFile(filePath, function(error, fileBody) {
+      if (error) {
+        error.message = "Error retrieving file from disk.\n" + error.stack + "\n\n" +
+          "Please report this full log at " +
+          "https://github.com/rxaviers/cldr-data-downloader";
+        fsDfd.reject(error);
+        throw error;
+      } else {
+        notify({total: totalSize, received: fileBody.length, percent: 100});
+        fsDfd.resolve(fileBody);
+      }
+  });
+
+  return fsDfd.promise;
+}
+
 function download(src) {
+  // Modify the src to not be a file protocol uri so we can unify handling files
+  if (src.url && src.url.trim().toLowerCase().indexOf("file://") === 0) {
+    // Chop off the first 7 characters
+    src.url = src.url.trim().substr("file://".length);
+  }
+  // Short circuit the download function and grab it from the filesystem if
+  // we don't have anything that looks like a protocol (e.g. https/http/ftp/etc).
+  if (src.url && src.url.indexOf("://") === -1) {
+    return fetchFromFilesystem(src);
+  }
+
   var downloadDfd = Q.defer();
   var options = getRequestOptions(src);
 


### PR DESCRIPTION
Hi!

This should add (hopefully cross platform, but I don't have a windows machine) support for specifying local files instead of urls for the 'downloader'. This allows users to override the need to hit an external server during a build.

The implementation is very similar the the url implementation. We just do some checking to make sure we want to grab files, and then asynchronously load the with `fs.readFile`. We have to make a few decisions on what 'relative' file paths will do. Since there isn't a sure-fire way to ensure we're at the root of a given project, I opted to just use `process.pwd()`, since that's configurable by the program that invokes it.

I mostly faked the 'downloader' bar, but on the off-chance people are mixing local stuff with remote stuff, it'll be good that it all looks uniform.

Fixes #25 
cc @rxaviers 