### PR TITLE
upgrade adm zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "adm-zip": "0.4.4",
+    "adm-zip": "0.4.11",
     "mkdirp": "0.5.0",
     "nopt": "3.0.x",
     "progress": "1.1.8",


### PR DESCRIPTION
Adm zip was vulnerable to [Arbitrary File Write Archive Extract](https://snyk.io/vuln/npm:adm-zip:20180415), upgrade to a version that fixed the vulnerability. 