### PR TITLE
High severity security alert due to obsolete dependency to "request"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "nopt": "3.0.x",
     "progress": "1.1.8",
     "q": "1.0.1",
-    "request": "~2.83.0",
+    "request": "~2.87.0",
     "request-progress": "0.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since I updated ``cldr-data`` in my project, this security warning raised:

![image](https://user-images.githubusercontent.com/214067/48050576-94129f00-e1a2-11e8-8160-c9832d238065.png)

It's caused by the following subtree:

```
myproject
└─┬ cldr-data@34.0.0
  └─┬ cldr-data-downloader@0.3.4
    └─┬ request@2.83.0
      └─┬ hawk@6.0.2
        └── cryptiles@3.1.3 
```

In reality, [``request`` dropped dependency to ``hawk``](https://github.com/request/request/commit/a6741d415aba31cd01e9c4544c96f84ea6ed11e3#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) since published version **``2.87.0``**

Upgrading ``package.json`` should fix this issue without breaking anything as it's a minor upgrade from ``request``.