### PR TITLE
Update : bump version of adm-zip from 0.4.13 to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "adm-zip": {
-      "version": "0.4.13",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-      "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw=="
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.3.tgz",
+      "integrity": "sha512-zsoTXEwRNCxBzRHLENFLuecCcwzzXiEhWo1r3GP68iwi8Q/hW2RrqgeY1nfJ/AhNQNWnZq/4v0TbfMsUkI+TYw=="
     },
     "argparse": {
       "version": "0.1.16",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "adm-zip": "0.4.13",
+    "adm-zip": "0.5.3",
     "axios": "^0.26.0",
     "mkdirp": "0.5.5",
     "nopt": "3.0.x",


### PR DESCRIPTION
Security vulnerability found in 0.4.3 and need to be updated to 0.5.3 : adm-zip package versions before 0.5.3 are vulnerable to Directory Traversal. It could extract files outside the target folder. origin: